### PR TITLE
Configure motion detection options

### DIFF
--- a/locales/en_US/LC_MESSAGES/terrariumpi.po
+++ b/locales/en_US/LC_MESSAGES/terrariumpi.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TerrariumPI 3.9.7\n"
-"POT-Creation-Date: 2019-07-08 19:40+CEST\n"
-"PO-Revision-Date: 2019-07-08 19:40+0200\n"
+"POT-Creation-Date: 2019-07-10 18:23+AEST\n"
+"PO-Revision-Date: 2019-07-10 18:24+1000\n"
 "Last-Translator: Joshua (TheYOSH) Rubingh <terrariumpi@theyosh.nl>\n"
 "Language-Team: \n"
 "Language: en_US\n"
@@ -16,16 +16,16 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 
 
-#: terrariumEngine.py:582 views/dashboard.tpl:7
+#: terrariumEngine.py:606 views/dashboard.tpl:7
 #: views/inc/usage_dashboard.tpl:87 views/system_status.tpl:230
 msgid "Uptime"
 msgstr "Uptime"
 
-#: terrariumEngine.py:583
+#: terrariumEngine.py:607
 msgid "Load"
 msgstr "Load"
 
-#: terrariumEngine.py:584
+#: terrariumEngine.py:608
 msgid "CPU Temp."
 msgstr "CPU Temp."
 
@@ -217,40 +217,52 @@ msgstr "Select the environment door state when enabling archiving."
 msgid "Enable or disable motion boxes for Motion archiving."
 msgstr "Enable or disable motion boxes for Motion archiving."
 
-#: terrariumTranslations.py:88
+#: terrariumTranslations.py:85
+msgid "Minimum difference between frames to be identified as motion. Higher value means that the image must be more different for motion to be detected."
+msgstr "Minimum difference between frames to be identified as motion. Higher value means that the image must be more different for motion to be detected."
+
+#: terrariumTranslations.py:86
+msgid "Minimum area of an image in pixels for a region to be considered motion. Larger values mean that only larger areas will be detected as motion."
+msgstr "Minimum area of an image in pixels for a region to be considered motion. Larger values mean that only larger areas will be detected as motion."
+
+#: terrariumTranslations.py:87
+msgid "Last frame means that only consecutive frames will be compared for motion. Last archived frame means that the current frame will be compared to the last archived frame. Setting to last frame will ignore motion when it is very gradual."
+msgstr "Last frame means that only consecutive frames will be compared for motion. Last archived frame means that the current frame will be compared to the last archived frame. Setting to last frame will ignore motion when it is very gradual."
+
+#: terrariumTranslations.py:91
 msgid "Holds the audio playlist name."
 msgstr "Holds the audio playlist name."
 
-#: terrariumTranslations.py:89
+#: terrariumTranslations.py:92
 msgid "Holds the time when the playlist should be started."
 msgstr "Holds the time when the playlist should be started."
 
-#: terrariumTranslations.py:90
+#: terrariumTranslations.py:93
 msgid "Holds the time when the playlist should be stopped."
 msgstr "Holds the time when the playlist should be stopped."
 
-#: terrariumTranslations.py:91
+#: terrariumTranslations.py:94
 msgid "Holds the volume for this playlist."
 msgstr "Holds the volume for this playlist."
 
-#: terrariumTranslations.py:92
+#: terrariumTranslations.py:95
 msgid "Toggle on to enable repeating of the audio files."
 msgstr "Toggle on to enable repeating of the audio files."
 
-#: terrariumTranslations.py:93
+#: terrariumTranslations.py:96
 msgid "Toggle on to enable shuffeling of the audio files."
 msgstr "Toggle on to enable shuffeling of the audio files."
 
-#: terrariumTranslations.py:94
+#: terrariumTranslations.py:97
 msgid "Select the audio files for this playlist. It is possible to select the same audio file in multiple playlists."
 msgstr "Select the audio files for this playlist. It is possible to select the same audio file in multiple playlists."
 
-#: terrariumTranslations.py:98
+#: terrariumTranslations.py:101
 msgid "Select the mode on which this environment part be put on and off. Select '%s' to use the sun rise and sun set at your location. This will make the amount of lighting variable to the actual amount of daylight. When selecting '%s', the light will put on and off at selected times."
 msgstr "Select the mode on which this environment part be put on and off. Select '%s' to use the sun rise and sun set at your location. This will make the amount of lighting variable to the actual amount of daylight. When selecting '%s', the light will put on and off at selected times."
 
-#: terrariumTranslations.py:98 terrariumTranslations.py:102
-#: terrariumTranslations.py:103 views/dashboard.tpl:83 views/dashboard.tpl:118
+#: terrariumTranslations.py:101 terrariumTranslations.py:105
+#: terrariumTranslations.py:106 views/dashboard.tpl:83 views/dashboard.tpl:118
 #: views/dashboard.tpl:171 views/dashboard.tpl:224 views/dashboard.tpl:277
 #: views/dashboard.tpl:330 views/dashboard.tpl:383 views/dashboard.tpl:436
 #: views/dashboard.tpl:489 views/dashboard.tpl:542
@@ -264,7 +276,7 @@ msgstr "Select the mode on which this environment part be put on and off. Select
 msgid "Timer"
 msgstr "Timer"
 
-#: terrariumTranslations.py:98 terrariumTranslations.py:110
+#: terrariumTranslations.py:101 terrariumTranslations.py:113
 #: views/inc/menu.tpl:30 views/inc/usage_environment.tpl:35
 #: views/inc/usage_environment.tpl:231 views/inc/usage_environment.tpl:325
 #: views/inc/usage_weather.tpl:13 views/inc/usage_weather.tpl:82
@@ -276,271 +288,271 @@ msgstr "Timer"
 msgid "Weather"
 msgstr "Weather"
 
-#: terrariumTranslations.py:99
+#: terrariumTranslations.py:102
 msgid "Select the sensors that are used to control this environment part. When selecting multiple sensors, the average is calculated to determine the final values."
 msgstr "Select the sensors that are used to control this environment part. When selecting multiple sensors, the average is calculated to determine the final values."
 
-#: terrariumTranslations.py:100
+#: terrariumTranslations.py:103
 msgid "Holds the value in degrees which the sensors are changing when it become night. Use positive numbers to increase the values and negative numbers to lower the values."
 msgstr "Holds the value in degrees which the sensors are changing when it become night. Use positive numbers to increase the values and negative numbers to lower the values."
 
-#: terrariumTranslations.py:101
+#: terrariumTranslations.py:104
 msgid "Holds the soure that is used to determing when it is day or night."
 msgstr "Holds the soure that is used to determing when it is day or night."
 
-#: terrariumTranslations.py:102
+#: terrariumTranslations.py:105
 msgid "Enter the time when this environment part should be put on. Only available when running in '%s' mode."
 msgstr "Enter the time when this environment part should be put on. Only available when running in '%s' mode."
 
-#: terrariumTranslations.py:103
+#: terrariumTranslations.py:106
 msgid "Enter the time when this environment part should be put off. Only available when running in '%s' mode."
 msgstr "Enter the time when this environment part should be put off. Only available when running in '%s' mode."
 
-#: terrariumTranslations.py:104
+#: terrariumTranslations.py:107
 msgid "Holds the period in minutes that this environment part is powered on withing the total timer window."
 msgstr "Holds the period in minutes that this environment part is powered on withing the total timer window."
 
-#: terrariumTranslations.py:105
+#: terrariumTranslations.py:108
 msgid "Holds the period in minutes that this environment part is powered off withing the total timer window."
 msgstr "Holds the period in minutes that this environment part is powered off withing the total timer window."
 
-#: terrariumTranslations.py:106
+#: terrariumTranslations.py:109
 msgid "How much time must there be between two actions and after start up. Enter the amount of seconds in which this environment part can settle."
 msgstr "How much time must there be between two actions and after start up. Enter the amount of seconds in which this environment part can settle."
 
-#: terrariumTranslations.py:107
+#: terrariumTranslations.py:110
 msgid "Holds the amount of seconds that this environment part is powered on when the value is out of range."
 msgstr "Holds the amount of seconds that this environment part is powered on when the value is out of range."
 
-#: terrariumTranslations.py:108
+#: terrariumTranslations.py:111
 msgid "Enter the maximum amount of time in hours. When the time between on and off is more then this maximum, the on and off time will be shifted more to each other."
 msgstr "Enter the maximum amount of time in hours. When the time between on and off is more then this maximum, the on and off time will be shifted more to each other."
 
-#: terrariumTranslations.py:109
+#: terrariumTranslations.py:112
 msgid "Enter the minimum amount of time in hours. When the time between on and off is less then this amount of hours, the on and off time will be widened until the minimum amount of hours entered here."
 msgstr "Enter the minimum amount of time in hours. When the time between on and off is less then this amount of hours, the on and off time will be widened until the minimum amount of hours entered here."
 
-#: terrariumTranslations.py:110
+#: terrariumTranslations.py:113
 msgid "Enter the amount of hours that the power on and off times should shift. Is only needed when running in the '%s' mode. Enter a positive number for adding hours to the start time. Use negative numbers for subtracting from the start time."
 msgstr "Enter the amount of hours that the power on and off times should shift. Is only needed when running in the '%s' mode. Enter a positive number for adding hours to the start time. Use negative numbers for subtracting from the start time."
 
-#: terrariumTranslations.py:111
+#: terrariumTranslations.py:114
 msgid "Select the power switches that should be used when the alarms or timers are hit. Select all needed switches below."
 msgstr "Select the power switches that should be used when the alarms or timers are hit. Select all needed switches below."
 
-#: terrariumTranslations.py:112
+#: terrariumTranslations.py:115
 msgid "Holds the water volume in liters."
 msgstr "Holds the water volume in liters."
 
-#: terrariumTranslations.py:113
+#: terrariumTranslations.py:116
 msgid "Holds the water tank height in cm or inches."
 msgstr "Holds the water tank height in cm or inches."
 
-#: terrariumTranslations.py:114
+#: terrariumTranslations.py:117
 msgid "Holds the distance between top of the liquid when full and the sensor in cm or inches."
 msgstr "Holds the distance between top of the liquid when full and the sensor in cm or inches."
 
-#: terrariumTranslations.py:115
+#: terrariumTranslations.py:118
 msgid "Select when the power switches can toggle. When lights are on, off or just always"
 msgstr "Select when the power switches can toggle. When lights are on, off or just always"
 
-#: terrariumTranslations.py:116
+#: terrariumTranslations.py:119
 msgid "Select when the power switches can toggle. When the door is open, cosed or just always"
 msgstr "Select when the power switches can toggle. When the door is open, cosed or just always"
 
-#: terrariumTranslations.py:120
+#: terrariumTranslations.py:123
 msgid "Holds the email address on which you would like to receive messages."
 msgstr "Holds the email address on which you would like to receive messages."
 
-#: terrariumTranslations.py:121
+#: terrariumTranslations.py:124
 msgid "Holds the mail server hostname or IP."
 msgstr "Holds the mail server hostname or IP."
 
-#: terrariumTranslations.py:122
+#: terrariumTranslations.py:125
 msgid "Holds the mail server portnumber. SSL and TLS will be autodetected."
 msgstr "Holds the mail server portnumber. SSL and TLS will be autodetected."
 
-#: terrariumTranslations.py:123
+#: terrariumTranslations.py:126
 msgid "Holds the username for authentication with the mailserver if needed."
 msgstr "Holds the username for authentication with the mailserver if needed."
 
-#: terrariumTranslations.py:124
+#: terrariumTranslations.py:127
 msgid "Holds the password for authentication with the mailserver if needed."
 msgstr "Holds the password for authentication with the mailserver if needed."
 
-#: terrariumTranslations.py:126
+#: terrariumTranslations.py:129
 msgid "Holds the display chip that is used."
 msgstr "Holds the display chip that is used."
 
-#: terrariumTranslations.py:127
+#: terrariumTranslations.py:130
 msgid "Holds the I2C address of the LCD screen. Use the value found with i2cdetect. Add ,[NR] to change the I2C bus."
 msgstr "Holds the I2C address of the LCD screen. Use the value found with i2cdetect. Add ,[NR] to change the I2C bus."
 
-#: terrariumTranslations.py:128
+#: terrariumTranslations.py:131
 msgid "Reserve first LCD line for static title."
 msgstr "Reserve first LCD line for static title."
 
-#: terrariumTranslations.py:130
+#: terrariumTranslations.py:133
 msgid "Holds your Twitter consumer key. More information %shere%s"
 msgstr "Holds your Twitter consumer key. More information %shere%s"
 
-#: terrariumTranslations.py:131
+#: terrariumTranslations.py:134
 msgid "Holds your Twitter consumer secret. More information %shere%s"
 msgstr "Holds your Twitter consumer secret. More information %shere%s"
 
-#: terrariumTranslations.py:132
+#: terrariumTranslations.py:135
 msgid "Holds your Twitter access token. More information %shere%s"
 msgstr "Holds your Twitter access token. More information %shere%s"
 
-#: terrariumTranslations.py:133
+#: terrariumTranslations.py:136
 msgid "Holds your Twitter access token secret. More information %shere%s"
 msgstr "Holds your Twitter access token secret. More information %shere%s"
 
-#: terrariumTranslations.py:135
+#: terrariumTranslations.py:138
 msgid "Holds the PushOver API token. More information %shere%s"
 msgstr "Holds the PushOver API token. More information %shere%s"
 
-#: terrariumTranslations.py:136
+#: terrariumTranslations.py:139
 msgid "Holds the PushOver API user key. More information %shere%s"
 msgstr "Holds the PushOver API user key. More information %shere%s"
 
-#: terrariumTranslations.py:138
+#: terrariumTranslations.py:141
 msgid "Holds the Telegram Bot token. More information %shere%s"
 msgstr "Holds the Telegram Bot token. More information %shere%s"
 
-#: terrariumTranslations.py:139
+#: terrariumTranslations.py:142
 msgid "Holds the Telegram username that is allowed for receiving messages. Can be multiple usernames seperated by a comma. More information %shere%s"
 msgstr "Holds the Telegram username that is allowed for receiving messages. Can be multiple usernames seperated by a comma. More information %shere%s"
 
-#: terrariumTranslations.py:140
+#: terrariumTranslations.py:143
 msgid "Holds the proxy address in form of [schema]://[user]:[password]@[server.com]:[port]. Can either be socks5 or http(s) for schema."
 msgstr "Holds the proxy address in form of [schema]://[user]:[password]@[server.com]:[port]. Can either be socks5 or http(s) for schema."
 
-#: terrariumTranslations.py:142
+#: terrariumTranslations.py:145
 msgid "Holds the url to post notification data to. You can use %name% variables in the post url"
 msgstr "Holds the url to post notification data to. You can use %name% variables in the post url"
 
-#: terrariumTranslations.py:147
+#: terrariumTranslations.py:150
 msgid "Choose your interface language."
 msgstr "Choose your interface language."
 
-#: terrariumTranslations.py:148
+#: terrariumTranslations.py:151
 msgid "Holds the distance type used by distance sensors."
 msgstr "Holds the distance type used by distance sensors."
 
-#: terrariumTranslations.py:149 terrariumTranslations.py:150
+#: terrariumTranslations.py:152 terrariumTranslations.py:153
 msgid "Holds the username which can make changes (Administrator)."
 msgstr "Holds the username which can make changes (Administrator)."
 
-#: terrariumTranslations.py:151
+#: terrariumTranslations.py:154
 msgid "Enter the new password for the administration user. Leaving empty will not change the password!"
 msgstr "Enter the new password for the administration user. Leaving empty will not change the password!"
 
-#: terrariumTranslations.py:152
+#: terrariumTranslations.py:155
 msgid "Enter the current password in order to change the password."
 msgstr "Enter the current password in order to change the password."
 
-#: terrariumTranslations.py:153
+#: terrariumTranslations.py:156
 msgid "Toggle on or off full authentication. When on, you need to authenticate at all times."
 msgstr "Toggle on or off full authentication. When on, you need to authenticate at all times."
 
-#: terrariumTranslations.py:154
+#: terrariumTranslations.py:157
 msgid "Holds the external calendar url."
 msgstr "Holds the external calendar url."
 
-#: terrariumTranslations.py:155
+#: terrariumTranslations.py:158
 msgid "Toggle on or off horizontal graph legends. Reload the webinterface after changing the setting."
 msgstr "Toggle on or off horizontal graph legends. Reload the webinterface after changing the setting."
 
-#: terrariumTranslations.py:156
+#: terrariumTranslations.py:159
 msgid "Toggle on or off the environment summary on the dashboard. Reload the webinterface after changing the setting."
 msgstr "Toggle on or off the environment summary on the dashboard. Reload the webinterface after changing the setting."
 
-#: terrariumTranslations.py:157
+#: terrariumTranslations.py:160
 msgid "Holds the soundcard that is used for playing audio."
 msgstr "Holds the soundcard that is used for playing audio."
 
-#: terrariumTranslations.py:158
+#: terrariumTranslations.py:161
 msgid "Holds the amount of power in Wattage that the Raspberry PI uses including all USB equipment."
 msgstr "Holds the amount of power in Wattage that the Raspberry PI uses including all USB equipment."
 
-#: terrariumTranslations.py:159
+#: terrariumTranslations.py:162
 msgid "Holds the amount of euro/dollar per 1 kW/h (1 Kilowatt per hour)."
 msgstr "Holds the amount of euro/dollar per 1 kW/h (1 Kilowatt per hour)."
 
-#: terrariumTranslations.py:160
+#: terrariumTranslations.py:163
 msgid "Holds the amount of euro/dollar per 1000 liters water."
 msgstr "Holds the amount of euro/dollar per 1000 liters water."
 
-#: terrariumTranslations.py:161
+#: terrariumTranslations.py:164
 msgid "Choose the temperature indicator. The software will recalculate to the chosen indicator."
 msgstr "Choose the temperature indicator. The software will recalculate to the chosen indicator."
 
-#: terrariumTranslations.py:162
+#: terrariumTranslations.py:165
 msgid "Choose the windspeed indicator. The software will recalculate to the chosen indicator."
 msgstr "Choose the windspeed indicator. The software will recalculate to the chosen indicator."
 
-#: terrariumTranslations.py:163
+#: terrariumTranslations.py:166
 msgid "Choose the volume (liquid) indicator. The software will recalculate to the chosen indicator."
 msgstr "Choose the volume (liquid) indicator. The software will recalculate to the chosen indicator."
 
-#: terrariumTranslations.py:164
+#: terrariumTranslations.py:167
 msgid "Holds the host name or IP address on which the software will listen for connections. Enter :: for all addresses to bind."
 msgstr "Holds the host name or IP address on which the software will listen for connections. Enter :: for all addresses to bind."
 
-#: terrariumTranslations.py:165
+#: terrariumTranslations.py:168
 msgid "Holds the port number on which the software is listening for connections."
 msgstr "Holds the port number on which the software is listening for connections."
 
-#: terrariumTranslations.py:166
+#: terrariumTranslations.py:169
 msgid "Enter the e-mail address that is used for your Meross devices."
 msgstr "Enter the e-mail address that is used for your Meross devices."
 
-#: terrariumTranslations.py:167
+#: terrariumTranslations.py:170
 msgid "Enter the password that is used for your Meross devices. Password is stored in plain text!"
 msgstr "Enter the password that is used for your Meross devices. Password is stored in plain text!"
 
-#: terrariumTranslations.py:168
+#: terrariumTranslations.py:171
 msgid "Holds the amount of datapoints (each 30 sec) to use for smoothing. The higher the value, the smoother the graph. Enter 0 to disable. Reload the webinterface after changing the setting."
 msgstr "Holds the amount of datapoints (each 30 sec) to use for smoothing. The higher the value, the smoother the graph. Enter 0 to disable. Reload the webinterface after changing the setting."
 
-#: terrariumTranslations.py:169
+#: terrariumTranslations.py:172
 msgid "Select true or false to show an extra sensor page which holds all the sensors with there gauges. Reload the webinterface after changing the setting."
 msgstr "Select true or false to show an extra sensor page which holds all the sensors with there gauges. Reload the webinterface after changing the setting."
 
-#: terrariumTranslations.py:174
+#: terrariumTranslations.py:177
 msgid "Holds the name of the animal."
 msgstr "Holds the name of the animal."
 
-#: terrariumTranslations.py:175
+#: terrariumTranslations.py:178
 msgid "Holds the type of the animal"
 msgstr "Holds the type of the animal"
 
-#: terrariumTranslations.py:176
+#: terrariumTranslations.py:179
 msgid "Holds the gender of the animal."
 msgstr "Holds the gender of the animal."
 
-#: terrariumTranslations.py:177
+#: terrariumTranslations.py:180
 msgid "Holds the day of birth of the animal."
 msgstr "Holds the day of birth of the animal."
 
-#: terrariumTranslations.py:178
+#: terrariumTranslations.py:181
 msgid "Holds the species name of the animal."
 msgstr "Holds the species name of the animal."
 
-#: terrariumTranslations.py:179
+#: terrariumTranslations.py:182
 msgid "Holds the latin name of the animal."
 msgstr "Holds the latin name of the animal."
 
-#: terrariumTranslations.py:180
+#: terrariumTranslations.py:183
 msgid "Holds a small description about the animal."
 msgstr "Holds a small description about the animal."
 
-#: terrariumTranslations.py:181
+#: terrariumTranslations.py:184
 msgid "Holds a link to more information."
 msgstr "Holds a link to more information."
 
-#: terrariumWebcam.py:187
+#: terrariumWebcam.py:190
 msgid "Offline since"
 msgstr "Offline since"
 
@@ -829,7 +841,7 @@ msgstr "new"
 #: views/switch_settings.tpl:151 views/switch_status.tpl:116
 #: views/webcam_settings.tpl:109 views/webcam_settings.tpl:123
 #: views/webcam_settings.tpl:142 views/webcam_settings.tpl:153
-#: views/webcam_settings.tpl:164
+#: views/webcam_settings.tpl:164 views/webcam_settings.tpl:186
 msgid "Select an option"
 msgstr "Select an option"
 
@@ -837,13 +849,13 @@ msgstr "Select an option"
 #: views/inc/usage_doors.tpl:70 views/inc/usage_sensors.tpl:81
 #: views/inc/usage_switches.tpl:70 views/inc/usage_webcams.tpl:66
 #: views/sensor_settings.tpl:203 views/switch_settings.tpl:208
-#: views/switch_status.tpl:132 views/webcam_settings.tpl:176
+#: views/switch_status.tpl:132 views/webcam_settings.tpl:198
 msgid "Close"
 msgstr "Close"
 
 #: views/audio_playlist.tpl:124 views/door_settings.tpl:95
 #: views/sensor_settings.tpl:204 views/switch_settings.tpl:209
-#: views/webcam_settings.tpl:177
+#: views/webcam_settings.tpl:199
 msgid "Add"
 msgstr "Add"
 
@@ -3192,6 +3204,26 @@ msgstr "When closed"
 msgid "Motion boxes"
 msgstr "Motion boxes"
 
+#: views/webcam_settings.tpl:171
+msgid "Motion delta threshold"
+msgstr "Motion delta threshold"
+
+#: views/webcam_settings.tpl:177
+msgid "Motion minimum area"
+msgstr "Motion minimum area"
+
+#: views/webcam_settings.tpl:183
+msgid "Motion comparison frame"
+msgstr "Motion comparison frame"
+
+#: views/webcam_settings.tpl:187
+msgid "Last frame"
+msgstr "Last frame"
+
+#: views/webcam_settings.tpl:188
+msgid "Last archived frame"
+msgstr "Last archived frame"
+
 #: Missing text string
 msgid "1Wire bus"
 msgstr "1Wire bus"
@@ -3377,6 +3409,10 @@ msgid "Load 5"
 msgstr "Load 5"
 
 #: Missing text string
+msgid "Minimum area"
+msgstr "Minimum area"
+
+#: Missing text string
 msgid "No error messages"
 msgstr "No error messages"
 
@@ -3455,6 +3491,10 @@ msgstr "TerrariumPI test setup"
 #: Missing text string
 msgid "There are zero door sensors configured."
 msgstr "There are zero door sensors configured."
+
+#: Missing text string
+msgid "Threshold"
+msgstr "Threshold"
 
 #: Missing text string
 msgid "Timer period off duration in minutes"

--- a/locales/terrariumpi.pot
+++ b/locales/terrariumpi.pot
@@ -5,7 +5,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: TerrariumPI 3.9.7\n"
-"POT-Creation-Date: 2019-07-08 19:40+CEST\n"
+"POT-Creation-Date: 2019-07-10 18:23+AEST\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,16 +15,16 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 
 
-#: terrariumEngine.py:582 views/dashboard.tpl:7
+#: terrariumEngine.py:606 views/dashboard.tpl:7
 #: views/inc/usage_dashboard.tpl:87 views/system_status.tpl:230
 msgid "Uptime"
 msgstr ""
 
-#: terrariumEngine.py:583
+#: terrariumEngine.py:607
 msgid "Load"
 msgstr ""
 
-#: terrariumEngine.py:584
+#: terrariumEngine.py:608
 msgid "CPU Temp."
 msgstr ""
 
@@ -216,40 +216,52 @@ msgstr ""
 msgid "Enable or disable motion boxes for Motion archiving."
 msgstr ""
 
-#: terrariumTranslations.py:88
-msgid "Holds the audio playlist name."
+#: terrariumTranslations.py:85
+msgid "Minimum difference between frames to be identified as motion. Higher value means that the image must be more different for motion to be detected."
 msgstr ""
 
-#: terrariumTranslations.py:89
-msgid "Holds the time when the playlist should be started."
+#: terrariumTranslations.py:86
+msgid "Minimum area of an image in pixels for a region to be considered motion. Larger values mean that only larger areas will be detected as motion."
 msgstr ""
 
-#: terrariumTranslations.py:90
-msgid "Holds the time when the playlist should be stopped."
+#: terrariumTranslations.py:87
+msgid "Last frame means that only consecutive frames will be compared for motion. Last archived frame means that the current frame will be compared to the last archived frame. Setting to last frame will ignore motion when it is very gradual."
 msgstr ""
 
 #: terrariumTranslations.py:91
-msgid "Holds the volume for this playlist."
+msgid "Holds the audio playlist name."
 msgstr ""
 
 #: terrariumTranslations.py:92
-msgid "Toggle on to enable repeating of the audio files."
+msgid "Holds the time when the playlist should be started."
 msgstr ""
 
 #: terrariumTranslations.py:93
-msgid "Toggle on to enable shuffeling of the audio files."
+msgid "Holds the time when the playlist should be stopped."
 msgstr ""
 
 #: terrariumTranslations.py:94
+msgid "Holds the volume for this playlist."
+msgstr ""
+
+#: terrariumTranslations.py:95
+msgid "Toggle on to enable repeating of the audio files."
+msgstr ""
+
+#: terrariumTranslations.py:96
+msgid "Toggle on to enable shuffeling of the audio files."
+msgstr ""
+
+#: terrariumTranslations.py:97
 msgid "Select the audio files for this playlist. It is possible to select the same audio file in multiple playlists."
 msgstr ""
 
-#: terrariumTranslations.py:98
+#: terrariumTranslations.py:101
 msgid "Select the mode on which this environment part be put on and off. Select '%s' to use the sun rise and sun set at your location. This will make the amount of lighting variable to the actual amount of daylight. When selecting '%s', the light will put on and off at selected times."
 msgstr ""
 
-#: terrariumTranslations.py:98 terrariumTranslations.py:102
-#: terrariumTranslations.py:103 views/dashboard.tpl:83 views/dashboard.tpl:118
+#: terrariumTranslations.py:101 terrariumTranslations.py:105
+#: terrariumTranslations.py:106 views/dashboard.tpl:83 views/dashboard.tpl:118
 #: views/dashboard.tpl:171 views/dashboard.tpl:224 views/dashboard.tpl:277
 #: views/dashboard.tpl:330 views/dashboard.tpl:383 views/dashboard.tpl:436
 #: views/dashboard.tpl:489 views/dashboard.tpl:542
@@ -263,7 +275,7 @@ msgstr ""
 msgid "Timer"
 msgstr ""
 
-#: terrariumTranslations.py:98 terrariumTranslations.py:110
+#: terrariumTranslations.py:101 terrariumTranslations.py:113
 #: views/inc/menu.tpl:30 views/inc/usage_environment.tpl:35
 #: views/inc/usage_environment.tpl:231 views/inc/usage_environment.tpl:325
 #: views/inc/usage_weather.tpl:13 views/inc/usage_weather.tpl:82
@@ -275,271 +287,271 @@ msgstr ""
 msgid "Weather"
 msgstr ""
 
-#: terrariumTranslations.py:99
+#: terrariumTranslations.py:102
 msgid "Select the sensors that are used to control this environment part. When selecting multiple sensors, the average is calculated to determine the final values."
 msgstr ""
 
-#: terrariumTranslations.py:100
+#: terrariumTranslations.py:103
 msgid "Holds the value in degrees which the sensors are changing when it become night. Use positive numbers to increase the values and negative numbers to lower the values."
 msgstr ""
 
-#: terrariumTranslations.py:101
+#: terrariumTranslations.py:104
 msgid "Holds the soure that is used to determing when it is day or night."
 msgstr ""
 
-#: terrariumTranslations.py:102
+#: terrariumTranslations.py:105
 msgid "Enter the time when this environment part should be put on. Only available when running in '%s' mode."
 msgstr ""
 
-#: terrariumTranslations.py:103
+#: terrariumTranslations.py:106
 msgid "Enter the time when this environment part should be put off. Only available when running in '%s' mode."
 msgstr ""
 
-#: terrariumTranslations.py:104
+#: terrariumTranslations.py:107
 msgid "Holds the period in minutes that this environment part is powered on withing the total timer window."
 msgstr ""
 
-#: terrariumTranslations.py:105
+#: terrariumTranslations.py:108
 msgid "Holds the period in minutes that this environment part is powered off withing the total timer window."
 msgstr ""
 
-#: terrariumTranslations.py:106
+#: terrariumTranslations.py:109
 msgid "How much time must there be between two actions and after start up. Enter the amount of seconds in which this environment part can settle."
 msgstr ""
 
-#: terrariumTranslations.py:107
+#: terrariumTranslations.py:110
 msgid "Holds the amount of seconds that this environment part is powered on when the value is out of range."
 msgstr ""
 
-#: terrariumTranslations.py:108
+#: terrariumTranslations.py:111
 msgid "Enter the maximum amount of time in hours. When the time between on and off is more then this maximum, the on and off time will be shifted more to each other."
 msgstr ""
 
-#: terrariumTranslations.py:109
+#: terrariumTranslations.py:112
 msgid "Enter the minimum amount of time in hours. When the time between on and off is less then this amount of hours, the on and off time will be widened until the minimum amount of hours entered here."
 msgstr ""
 
-#: terrariumTranslations.py:110
+#: terrariumTranslations.py:113
 msgid "Enter the amount of hours that the power on and off times should shift. Is only needed when running in the '%s' mode. Enter a positive number for adding hours to the start time. Use negative numbers for subtracting from the start time."
 msgstr ""
 
-#: terrariumTranslations.py:111
+#: terrariumTranslations.py:114
 msgid "Select the power switches that should be used when the alarms or timers are hit. Select all needed switches below."
 msgstr ""
 
-#: terrariumTranslations.py:112
+#: terrariumTranslations.py:115
 msgid "Holds the water volume in liters."
 msgstr ""
 
-#: terrariumTranslations.py:113
+#: terrariumTranslations.py:116
 msgid "Holds the water tank height in cm or inches."
 msgstr ""
 
-#: terrariumTranslations.py:114
+#: terrariumTranslations.py:117
 msgid "Holds the distance between top of the liquid when full and the sensor in cm or inches."
 msgstr ""
 
-#: terrariumTranslations.py:115
+#: terrariumTranslations.py:118
 msgid "Select when the power switches can toggle. When lights are on, off or just always"
 msgstr ""
 
-#: terrariumTranslations.py:116
+#: terrariumTranslations.py:119
 msgid "Select when the power switches can toggle. When the door is open, cosed or just always"
 msgstr ""
 
-#: terrariumTranslations.py:120
+#: terrariumTranslations.py:123
 msgid "Holds the email address on which you would like to receive messages."
 msgstr ""
 
-#: terrariumTranslations.py:121
+#: terrariumTranslations.py:124
 msgid "Holds the mail server hostname or IP."
 msgstr ""
 
-#: terrariumTranslations.py:122
+#: terrariumTranslations.py:125
 msgid "Holds the mail server portnumber. SSL and TLS will be autodetected."
 msgstr ""
 
-#: terrariumTranslations.py:123
+#: terrariumTranslations.py:126
 msgid "Holds the username for authentication with the mailserver if needed."
 msgstr ""
 
-#: terrariumTranslations.py:124
+#: terrariumTranslations.py:127
 msgid "Holds the password for authentication with the mailserver if needed."
 msgstr ""
 
-#: terrariumTranslations.py:126
+#: terrariumTranslations.py:129
 msgid "Holds the display chip that is used."
 msgstr ""
 
-#: terrariumTranslations.py:127
+#: terrariumTranslations.py:130
 msgid "Holds the I2C address of the LCD screen. Use the value found with i2cdetect. Add ,[NR] to change the I2C bus."
 msgstr ""
 
-#: terrariumTranslations.py:128
+#: terrariumTranslations.py:131
 msgid "Reserve first LCD line for static title."
 msgstr ""
 
-#: terrariumTranslations.py:130
+#: terrariumTranslations.py:133
 msgid "Holds your Twitter consumer key. More information %shere%s"
 msgstr ""
 
-#: terrariumTranslations.py:131
+#: terrariumTranslations.py:134
 msgid "Holds your Twitter consumer secret. More information %shere%s"
 msgstr ""
 
-#: terrariumTranslations.py:132
+#: terrariumTranslations.py:135
 msgid "Holds your Twitter access token. More information %shere%s"
 msgstr ""
 
-#: terrariumTranslations.py:133
+#: terrariumTranslations.py:136
 msgid "Holds your Twitter access token secret. More information %shere%s"
 msgstr ""
 
-#: terrariumTranslations.py:135
+#: terrariumTranslations.py:138
 msgid "Holds the PushOver API token. More information %shere%s"
 msgstr ""
 
-#: terrariumTranslations.py:136
+#: terrariumTranslations.py:139
 msgid "Holds the PushOver API user key. More information %shere%s"
 msgstr ""
 
-#: terrariumTranslations.py:138
+#: terrariumTranslations.py:141
 msgid "Holds the Telegram Bot token. More information %shere%s"
 msgstr ""
 
-#: terrariumTranslations.py:139
+#: terrariumTranslations.py:142
 msgid "Holds the Telegram username that is allowed for receiving messages. Can be multiple usernames seperated by a comma. More information %shere%s"
 msgstr ""
 
-#: terrariumTranslations.py:140
+#: terrariumTranslations.py:143
 msgid "Holds the proxy address in form of [schema]://[user]:[password]@[server.com]:[port]. Can either be socks5 or http(s) for schema."
 msgstr ""
 
-#: terrariumTranslations.py:142
+#: terrariumTranslations.py:145
 msgid "Holds the url to post notification data to. You can use %name% variables in the post url"
 msgstr ""
 
-#: terrariumTranslations.py:147
+#: terrariumTranslations.py:150
 msgid "Choose your interface language."
 msgstr ""
 
-#: terrariumTranslations.py:148
+#: terrariumTranslations.py:151
 msgid "Holds the distance type used by distance sensors."
 msgstr ""
 
-#: terrariumTranslations.py:149 terrariumTranslations.py:150
+#: terrariumTranslations.py:152 terrariumTranslations.py:153
 msgid "Holds the username which can make changes (Administrator)."
 msgstr ""
 
-#: terrariumTranslations.py:151
+#: terrariumTranslations.py:154
 msgid "Enter the new password for the administration user. Leaving empty will not change the password!"
 msgstr ""
 
-#: terrariumTranslations.py:152
+#: terrariumTranslations.py:155
 msgid "Enter the current password in order to change the password."
 msgstr ""
 
-#: terrariumTranslations.py:153
+#: terrariumTranslations.py:156
 msgid "Toggle on or off full authentication. When on, you need to authenticate at all times."
 msgstr ""
 
-#: terrariumTranslations.py:154
+#: terrariumTranslations.py:157
 msgid "Holds the external calendar url."
 msgstr ""
 
-#: terrariumTranslations.py:155
+#: terrariumTranslations.py:158
 msgid "Toggle on or off horizontal graph legends. Reload the webinterface after changing the setting."
 msgstr ""
 
-#: terrariumTranslations.py:156
+#: terrariumTranslations.py:159
 msgid "Toggle on or off the environment summary on the dashboard. Reload the webinterface after changing the setting."
 msgstr ""
 
-#: terrariumTranslations.py:157
+#: terrariumTranslations.py:160
 msgid "Holds the soundcard that is used for playing audio."
 msgstr ""
 
-#: terrariumTranslations.py:158
+#: terrariumTranslations.py:161
 msgid "Holds the amount of power in Wattage that the Raspberry PI uses including all USB equipment."
 msgstr ""
 
-#: terrariumTranslations.py:159
+#: terrariumTranslations.py:162
 msgid "Holds the amount of euro/dollar per 1 kW/h (1 Kilowatt per hour)."
 msgstr ""
 
-#: terrariumTranslations.py:160
+#: terrariumTranslations.py:163
 msgid "Holds the amount of euro/dollar per 1000 liters water."
 msgstr ""
 
-#: terrariumTranslations.py:161
+#: terrariumTranslations.py:164
 msgid "Choose the temperature indicator. The software will recalculate to the chosen indicator."
 msgstr ""
 
-#: terrariumTranslations.py:162
+#: terrariumTranslations.py:165
 msgid "Choose the windspeed indicator. The software will recalculate to the chosen indicator."
 msgstr ""
 
-#: terrariumTranslations.py:163
+#: terrariumTranslations.py:166
 msgid "Choose the volume (liquid) indicator. The software will recalculate to the chosen indicator."
 msgstr ""
 
-#: terrariumTranslations.py:164
+#: terrariumTranslations.py:167
 msgid "Holds the host name or IP address on which the software will listen for connections. Enter :: for all addresses to bind."
 msgstr ""
 
-#: terrariumTranslations.py:165
+#: terrariumTranslations.py:168
 msgid "Holds the port number on which the software is listening for connections."
 msgstr ""
 
-#: terrariumTranslations.py:166
+#: terrariumTranslations.py:169
 msgid "Enter the e-mail address that is used for your Meross devices."
 msgstr ""
 
-#: terrariumTranslations.py:167
+#: terrariumTranslations.py:170
 msgid "Enter the password that is used for your Meross devices. Password is stored in plain text!"
 msgstr ""
 
-#: terrariumTranslations.py:168
+#: terrariumTranslations.py:171
 msgid "Holds the amount of datapoints (each 30 sec) to use for smoothing. The higher the value, the smoother the graph. Enter 0 to disable. Reload the webinterface after changing the setting."
 msgstr ""
 
-#: terrariumTranslations.py:169
+#: terrariumTranslations.py:172
 msgid "Select true or false to show an extra sensor page which holds all the sensors with there gauges. Reload the webinterface after changing the setting."
 msgstr ""
 
-#: terrariumTranslations.py:174
+#: terrariumTranslations.py:177
 msgid "Holds the name of the animal."
 msgstr ""
 
-#: terrariumTranslations.py:175
+#: terrariumTranslations.py:178
 msgid "Holds the type of the animal"
 msgstr ""
 
-#: terrariumTranslations.py:176
+#: terrariumTranslations.py:179
 msgid "Holds the gender of the animal."
 msgstr ""
 
-#: terrariumTranslations.py:177
+#: terrariumTranslations.py:180
 msgid "Holds the day of birth of the animal."
 msgstr ""
 
-#: terrariumTranslations.py:178
+#: terrariumTranslations.py:181
 msgid "Holds the species name of the animal."
 msgstr ""
 
-#: terrariumTranslations.py:179
+#: terrariumTranslations.py:182
 msgid "Holds the latin name of the animal."
 msgstr ""
 
-#: terrariumTranslations.py:180
+#: terrariumTranslations.py:183
 msgid "Holds a small description about the animal."
 msgstr ""
 
-#: terrariumTranslations.py:181
+#: terrariumTranslations.py:184
 msgid "Holds a link to more information."
 msgstr ""
 
-#: terrariumWebcam.py:187
+#: terrariumWebcam.py:190
 msgid "Offline since"
 msgstr ""
 
@@ -828,7 +840,7 @@ msgstr ""
 #: views/switch_settings.tpl:151 views/switch_status.tpl:116
 #: views/webcam_settings.tpl:109 views/webcam_settings.tpl:123
 #: views/webcam_settings.tpl:142 views/webcam_settings.tpl:153
-#: views/webcam_settings.tpl:164
+#: views/webcam_settings.tpl:164 views/webcam_settings.tpl:186
 msgid "Select an option"
 msgstr ""
 
@@ -836,13 +848,13 @@ msgstr ""
 #: views/inc/usage_doors.tpl:70 views/inc/usage_sensors.tpl:81
 #: views/inc/usage_switches.tpl:70 views/inc/usage_webcams.tpl:66
 #: views/sensor_settings.tpl:203 views/switch_settings.tpl:208
-#: views/switch_status.tpl:132 views/webcam_settings.tpl:176
+#: views/switch_status.tpl:132 views/webcam_settings.tpl:198
 msgid "Close"
 msgstr ""
 
 #: views/audio_playlist.tpl:124 views/door_settings.tpl:95
 #: views/sensor_settings.tpl:204 views/switch_settings.tpl:209
-#: views/webcam_settings.tpl:177
+#: views/webcam_settings.tpl:199
 msgid "Add"
 msgstr ""
 
@@ -3191,6 +3203,26 @@ msgstr ""
 msgid "Motion boxes"
 msgstr ""
 
+#: views/webcam_settings.tpl:171
+msgid "Motion delta threshold"
+msgstr ""
+
+#: views/webcam_settings.tpl:177
+msgid "Motion minimum area"
+msgstr ""
+
+#: views/webcam_settings.tpl:183
+msgid "Motion comparison frame"
+msgstr ""
+
+#: views/webcam_settings.tpl:187
+msgid "Last frame"
+msgstr ""
+
+#: views/webcam_settings.tpl:188
+msgid "Last archived frame"
+msgstr ""
+
 #: Missing text string
 msgid "1Wire bus"
 msgstr ""
@@ -3376,6 +3408,10 @@ msgid "Load 5"
 msgstr ""
 
 #: Missing text string
+msgid "Minimum area"
+msgstr ""
+
+#: Missing text string
 msgid "No error messages"
 msgstr ""
 
@@ -3453,6 +3489,10 @@ msgstr ""
 
 #: Missing text string
 msgid "There are zero door sensors configured."
+msgstr ""
+
+#: Missing text string
+msgid "Threshold"
 msgstr ""
 
 #: Missing text string

--- a/static/js/terrariumpi.js
+++ b/static/js/terrariumpi.js
@@ -2545,6 +2545,11 @@ function add_webcam_setting_row(data,is_new) {
     minimumResultsForSearch: Infinity
   }).on('change',function() {
     $(this).parents('.x_content').find('img').removeClass('webcam_90 webcam_180 webcam_270 webcam_H webcam_V').addClass('webcam_' + this.value);
+
+    if (this.name.endsWith('_archive')) {
+      var motionEnabled = ('motion' === this.value);
+      $(this).parents('.x_content').find('.motion_option').toggle(motionEnabled);
+    }
   });
   // Add on the bottom before the submit row
   setting_row.insertBefore('div.row.submit');

--- a/terrariumEngine.py
+++ b/terrariumEngine.py
@@ -440,11 +440,11 @@ class terrariumEngine(object):
                                    archive,
                                    archive_light,
                                    archive_door,
-                                   self.environment,
-                                   motion_boxes,
-                                   motion_delta_threshold,
-                                   motion_min_area,
-                                   motion_compare_frame)
+                                   self.environment)
+          webcam.set_motion_boxes(motion_boxes)
+          webcam.set_motion_delta_threshold(motion_delta_threshold)
+          webcam.set_motion_min_area(motion_min_area)
+          webcam.set_motion_compare_frame(motion_compare_frame)
           self.webcams[webcam.get_id()] = webcam
         except Exception as err:
           print(err)

--- a/terrariumEngine.py
+++ b/terrariumEngine.py
@@ -401,6 +401,9 @@ class terrariumEngine(object):
         archive_light = 'ignore'
         archive_door = 'ignore'
         motion_boxes = True
+        motion_delta_threshold = 25
+        motion_min_area = 500
+        motion_compare_frame = 'last'
 
         if 'resolution_width' in webcamdata and 'resolution_height' in webcamdata:
           width = webcamdata['resolution_width']
@@ -418,6 +421,15 @@ class terrariumEngine(object):
         if 'motionboxes' in webcamdata:
           motion_boxes = webcamdata['motionboxes']
 
+        if 'motion_delta_threshold' in webcamdata:
+          motion_delta_threshold = webcamdata['motiondeltathreshold']
+
+        if 'motion_min_area' in webcamdata:
+          motion_min_area = webcamdata['motionminarea']
+
+        if 'motion_compare_frame' in webcamdata:
+          motion_compare_frame = webcamdata['motioncompareframe']
+
         # don't let bad location data kill the system
         try:
           webcam = terrariumWebcam(None,
@@ -429,7 +441,10 @@ class terrariumEngine(object):
                                    archive_light,
                                    archive_door,
                                    self.environment,
-                                   motion_boxes)
+                                   motion_boxes,
+                                   motion_delta_threshold,
+                                   motion_min_area,
+                                   motion_compare_frame)
           self.webcams[webcam.get_id()] = webcam
         except Exception as err:
           print(err)
@@ -458,6 +473,15 @@ class terrariumEngine(object):
 
       if 'motionboxes' in webcamdata:
         webcam.set_motion_boxes(webcamdata['motionboxes'])
+
+      if 'motiondeltathreshold' in webcamdata:
+        webcam.set_motion_delta_threshold(webcamdata['motiondeltathreshold'])
+
+      if 'motionminarea' in webcamdata:
+        webcam.set_motion_min_area(webcamdata['motionminarea'])
+
+      if 'motioncompareframe' in webcamdata:
+        webcam.set_motion_compare_frame(webcamdata['motioncompareframe'])
 
       seen_webcams.append(webcam.get_id())
 

--- a/terrariumTranslations.py
+++ b/terrariumTranslations.py
@@ -82,6 +82,9 @@ class terrariumTranslations(object):
     self.translations['webcam_field_archive_light'] = _('Select the environment light state when enabling archiving.')
     self.translations['webcam_field_archive_door'] = _('Select the environment door state when enabling archiving.')
     self.translations['webcam_field_motion_boxes'] = _('Enable or disable motion boxes for Motion archiving.')
+    self.translations['webcam_field_motion_delta_threshold'] = _('Minimum difference between frames to be identified as motion. Higher value means that the image must be more different for motion to be detected.')
+    self.translations['webcam_field_motion_min_area'] = _('Minimum area of an image in pixels for a region to be considered motion. Larger values mean that only larger areas will be detected as motion.')
+    self.translations['webcam_field_motion_compare_frame'] = _('Last frame means that only consecutive frames will be compared for motion. Last archived frame means that the current frame will be compared to the last archived frame. Setting to last frame will ignore motion when it is very gradual.')
     # End webcam
 
     # Audio

--- a/terrariumWebcam.py
+++ b/terrariumWebcam.py
@@ -50,7 +50,7 @@ class terrariumWebcamSource(object):
   UPDATE_TIMEOUT = 60
   VALID_ROTATIONS = ['0','90','180','270','h','v']
 
-  def __init__(self, webcam_id, location, name = '', rotation = '0', width = 640, height = 480, archive = False, archive_light = 'ignore', archive_door = 'ignore', environment = None, motion_boxes = True, motion_delta_threshold = 25, motion_min_area = 500, motion_compare_frame = 'last'):
+  def __init__(self, webcam_id, location, name = '', rotation = '0', width = 640, height = 480, archive = False, archive_light = 'ignore', archive_door = 'ignore', environment = None):
     # Variables per webcam
     self.raw_image = None
 
@@ -64,6 +64,12 @@ class terrariumWebcamSource(object):
     self.__state = None
     self.__environment = environment
 
+    # set defaults
+    self.set_motion_boxes(True)
+    self.set_motion_delta_threshold(25)
+    self.set_motion_min_area(500)
+    self.set_motion_compare_frame('last')
+
     # Per webcam config
     self.set_location(location)
     self.set_name(name)
@@ -72,10 +78,6 @@ class terrariumWebcamSource(object):
     self.set_archive(archive)
     self.set_archive_light(archive_light)
     self.set_archive_door(archive_door)
-    self.set_motion_boxes(motion_boxes)
-    self.set_motion_delta_threshold(motion_delta_threshold)
-    self.set_motion_min_area(motion_min_area)
-    self.set_motion_compare_frame(motion_compare_frame)
 
     if webcam_id is None:
       self.__id = md5(self.get_location().encode()).hexdigest()
@@ -473,8 +475,8 @@ class terrariumWebcamSource(object):
     return False
 
 class terrariumWebcamLiveSource(terrariumWebcamSource):
-  def __init__(self, webcam_id, location, name = '', rotation = '0', width = 640, height = 480, archive = False, archive_light = 'ignore', archive_door = 'ignore', environment = None, motion_boxes = True, motion_delta_threshold = 25, motion_min_area = 500, motion_compare_frame = 'last'):
-    super(terrariumWebcamLiveSource,self).__init__(webcam_id, location, name, rotation, width, height, archive, archive_light, archive_door, environment, motion_boxes, motion_delta_threshold, motion_min_area, motion_compare_frame)
+  def __init__(self, webcam_id, location, name = '', rotation = '0', width = 640, height = 480, archive = False, archive_light = 'ignore', archive_door = 'ignore', environment = None):
+    super(terrariumWebcamLiveSource,self).__init__(webcam_id, location, name, rotation, width, height, archive, archive_light, archive_door, environment)
     self.process_id = None
     self.start()
 
@@ -657,10 +659,10 @@ class terrariumWebcam(object):
              terrariumWebcamRPILive,
              terrariumWebcamHLSLive]
 
-  def __new__(self,webcam_id, location, name = '', rotation = '0', width = 640, height = 480, archive = False, archive_light = 'ignore', archive_door = 'ignore', environment = None, motion_boxes = True, motion_delta_threshold = 25, motion_min_area = 500, motion_compare_frame = 'last'):
+  def __new__(self,webcam_id, location, name = '', rotation = '0', width = 640, height = 480, archive = False, archive_light = 'ignore', archive_door = 'ignore', environment = None):
     for webcam_source in terrariumWebcam.SOURCES:
       if re.search(webcam_source.VALID_SOURCE, location, re.IGNORECASE):
-        return webcam_source(webcam_id,location,name,rotation,width,height,archive,archive_light,archive_door,environment, motion_boxes, motion_delta_threshold, motion_min_area, motion_compare_frame)
+        return webcam_source(webcam_id,location,name,rotation,width,height,archive,archive_light,archive_door,environment)
 
     raise terrariumWebcamSourceException()
 

--- a/views/webcam_settings.tpl
+++ b/views/webcam_settings.tpl
@@ -157,36 +157,38 @@
                             </select>
                           </div>
                         </div>
-                        <div class="col-md-2 col-sm-2 col-xs-6 form-group">
-                          <label for="webcam_[nr]_motionboxes">{{_('Motion boxes')}}</label>
-                          <div class="form-group" data-toggle="tooltip" data-placement="top" title="" data-original-title="{{translations.get_translation('webcam_field_motion_boxes')}}">
-                            <select class="form-control" name="webcam_[nr]_motionboxes" tabindex="-1" placeholder="{{_('Select an option')}}">
-                              <option value="">{{_('Select an option')}}</option>
-                              <option value="true">{{_('Enabled')}}</option>
-                              <option value="false">{{_('Disabled')}}</option>
-                            </select>
+                        <div class="motion_option" style="display:none;">
+                          <div class="col-md-2 col-sm-2 col-xs-6 form-group">
+                            <label for="webcam_[nr]_motionboxes">{{_('Motion boxes')}}</label>
+                            <div class="form-group" data-toggle="tooltip" data-placement="top" title="" data-original-title="{{translations.get_translation('webcam_field_motion_boxes')}}">
+                              <select class="form-control" name="webcam_[nr]_motionboxes" tabindex="-1" placeholder="{{_('Select an option')}}">
+                                <option value="">{{_('Select an option')}}</option>
+                                <option value="true">{{_('Enabled')}}</option>
+                                <option value="false">{{_('Disabled')}}</option>
+                              </select>
+                            </div>
                           </div>
-                        </div>
-                        <div class="col-md-2 col-sm-2 col-xs-6 form-group">
-                          <label for="webcam_[nr]_motiondeltathreshold">{{_('Motion delta threshold')}}</label>
-                          <div class="form-group">
-                            <input class="form-control" name="webcam_[nr]_motiondeltathreshold" placeholder="{{_('Threshold')}}" type="text" data-toggle="tooltip" data-placement="bottom" title="" pattern="[0-9]+" data-original-title="{{translations.get_translation('webcam_field_motion_delta_threshold')}}">
+                          <div class="col-md-2 col-sm-2 col-xs-6 form-group">
+                            <label for="webcam_[nr]_motiondeltathreshold">{{_('Motion delta threshold')}}</label>
+                            <div class="form-group">
+                              <input class="form-control" name="webcam_[nr]_motiondeltathreshold" placeholder="{{_('Threshold')}}" type="text" data-toggle="tooltip" data-placement="bottom" title="" pattern="[0-9]+" data-original-title="{{translations.get_translation('webcam_field_motion_delta_threshold')}}">
+                            </div>
                           </div>
-                        </div>
-                        <div class="col-md-2 col-sm-2 col-xs-6 form-group">
-                          <label for="webcam_[nr]_motionminarea">{{_('Motion minimum area')}}</label>
-                          <div class="form-group">
-                            <input class="form-control" name="webcam_[nr]_motionminarea" placeholder="{{_('Minimum area')}}" type="text" data-toggle="tooltip" data-placement="bottom" title="" pattern="[0-9]+" data-original-title="{{translations.get_translation('webcam_field_motion_min_area')}}">
+                          <div class="col-md-2 col-sm-2 col-xs-6 form-group">
+                            <label for="webcam_[nr]_motionminarea">{{_('Motion minimum area')}}</label>
+                            <div class="form-group">
+                              <input class="form-control" name="webcam_[nr]_motionminarea" placeholder="{{_('Minimum area')}}" type="text" data-toggle="tooltip" data-placement="bottom" title="" pattern="[0-9]+" data-original-title="{{translations.get_translation('webcam_field_motion_min_area')}}">
+                            </div>
                           </div>
-                        </div>
-                        <div class="col-md-2 col-sm-2 col-xs-6 form-group">
-                          <label for="webcam_[nr]_motioncompareframe">{{_('Motion comparison frame')}}</label>
-                          <div class="form-group" data-toggle="tooltip" data-placement="top" title="" data-original-title="{{translations.get_translation('webcam_field_motion_compare_frame')}}">
-                            <select class="form-control" name="webcam_[nr]_motioncompareframe" tabindex="-1" placeholder="{{_('Select an option')}}">
-                              <option value="">{{_('Select an option')}}</option>
-                              <option value="last">{{_('Last frame')}}</option>
-                              <option value="archived">{{_('Last archived frame')}}</option>
-                            </select>
+                          <div class="col-md-2 col-sm-2 col-xs-6 form-group">
+                            <label for="webcam_[nr]_motioncompareframe">{{_('Motion comparison frame')}}</label>
+                            <div class="form-group" data-toggle="tooltip" data-placement="top" title="" data-original-title="{{translations.get_translation('webcam_field_motion_compare_frame')}}">
+                              <select class="form-control" name="webcam_[nr]_motioncompareframe" tabindex="-1" placeholder="{{_('Select an option')}}">
+                                <option value="">{{_('Select an option')}}</option>
+                                <option value="last">{{_('Last frame')}}</option>
+                                <option value="archived">{{_('Last archived frame')}}</option>
+                              </select>
+                            </div>
                           </div>
                         </div>
                       </div>
@@ -210,6 +212,11 @@
               placeholder: '{{_('Select an option')}}',
               allowClear: false,
               minimumResultsForSearch: Infinity
+            }).on('change',function() {
+              if (this.name.endsWith('_archive')) {
+                var motionEnabled = ('motion' === this.value);
+                $(this).parents('.x_content').find('.motion_option').toggle(motionEnabled);
+              }
             });
 
             $.get($('form').attr('action'),function(json_data){

--- a/views/webcam_settings.tpl
+++ b/views/webcam_settings.tpl
@@ -167,6 +167,28 @@
                             </select>
                           </div>
                         </div>
+                        <div class="col-md-2 col-sm-2 col-xs-6 form-group">
+                          <label for="webcam_[nr]_motiondeltathreshold">{{_('Motion delta threshold')}}</label>
+                          <div class="form-group">
+                            <input class="form-control" name="webcam_[nr]_motiondeltathreshold" placeholder="{{_('Threshold')}}" type="text" data-toggle="tooltip" data-placement="bottom" title="" pattern="[0-9]+" data-original-title="{{translations.get_translation('webcam_field_motion_delta_threshold')}}">
+                          </div>
+                        </div>
+                        <div class="col-md-2 col-sm-2 col-xs-6 form-group">
+                          <label for="webcam_[nr]_motionminarea">{{_('Motion minimum area')}}</label>
+                          <div class="form-group">
+                            <input class="form-control" name="webcam_[nr]_motionminarea" placeholder="{{_('Minimum area')}}" type="text" data-toggle="tooltip" data-placement="bottom" title="" pattern="[0-9]+" data-original-title="{{translations.get_translation('webcam_field_motion_min_area')}}">
+                          </div>
+                        </div>
+                        <div class="col-md-2 col-sm-2 col-xs-6 form-group">
+                          <label for="webcam_[nr]_motioncompareframe">{{_('Motion comparison frame')}}</label>
+                          <div class="form-group" data-toggle="tooltip" data-placement="top" title="" data-original-title="{{translations.get_translation('webcam_field_motion_compare_frame')}}">
+                            <select class="form-control" name="webcam_[nr]_motioncompareframe" tabindex="-1" placeholder="{{_('Select an option')}}">
+                              <option value="">{{_('Select an option')}}</option>
+                              <option value="last">{{_('Last frame')}}</option>
+                              <option value="archived">{{_('Last archived frame')}}</option>
+                            </select>
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
The existing motion detection settings result in a lot of false positives if your camera image is quite noisy (such as from banding from a led light). This change allows the user to configure the minimum difference threshold between images before motion is triggered, and a minimum area of difference. It also allows the user to have the system compare either the last captured frame or the last archived frame. The former setting will only capture motion between consecutive frames, whereas the latter option captures motion that slowly occurs over time.

I've also made it so that the motion options are only shown if Motion is selected from the Archive dropdown.