### PR TITLE
Cancel existing switch timer when toggling state

### DIFF
--- a/terrariumEnvironment.py
+++ b/terrariumEnvironment.py
@@ -31,6 +31,7 @@ class terrariumEnvironmentPart(object):
     self.timer_max_data = {'lastaction' : 0, 'power_state' : None}
 
     self.last_update = 0
+    self.active_timer = None
 
   def __get_power_state(self,powerswitchlist):
     self.timer_min_data['max_power'] = False
@@ -97,12 +98,12 @@ class terrariumEnvironmentPart(object):
       self.__toggle_powerswitches(switches,action)
 
       timerdata['lastaction'] = now
-      if 'lasttimer' in timerdata:
-        timerdata['lasttimer'].cancel()
+      if self.active_timer != None:
+        self.active_timer.cancel()
+        self.active_timer = None
       if 'on' == action and onduration > 0:
-        timer = Timer(onduration, self.toggle_off_alarm_min if 'min' == part else self.toggle_off_alarm_max, (powerswitchlist,True))
-        timer.start()
-        timerdata['lasttimer'] = timer
+        self.active_timer = Timer(onduration, self.toggle_off_alarm_min if 'min' == part else self.toggle_off_alarm_max, (powerswitchlist,True))
+        self.active_timer.start()
 
   def set_alarm_min(self,start,stop,timer_on,timer_off,light_state,door_state,duration_on,settle,powerswitches):
     self.config['alarm_min'] = {'timer_start':start,

--- a/terrariumEnvironment.py
+++ b/terrariumEnvironment.py
@@ -72,17 +72,20 @@ class terrariumEnvironmentPart(object):
     lastaction = 0
     settletime = 0
     onduration = 0
+    timerdata = {}
 
     if 'min' == part:
       powerswitches = self.config['alarm_min']['powerswitches']
       settletime = self.config['alarm_min']['settle']
       onduration = self.config['alarm_min']['duration_on']
-      lastaction = self.timer_min_data['lastaction']
+      timerdata = self.timer_min_data
+      lastaction = timerdata['lastaction']      
     elif 'max' == part:
       powerswitches = self.config['alarm_max']['powerswitches']
       settletime = self.config['alarm_max']['settle']
       onduration = self.config['alarm_max']['duration_on']
-      lastaction = self.timer_max_data['lastaction']
+      timerdata = self.timer_max_data
+      lastaction = timerdata['lastaction']
 
     if len(powerswitches) == 0:
       return
@@ -93,15 +96,13 @@ class terrariumEnvironmentPart(object):
 
       self.__toggle_powerswitches(switches,action)
 
-      if 'min' == part:
-        self.timer_min_data['lastaction'] = now
-        if 'on' == action and onduration > 0:
-          (Timer(onduration, self.toggle_off_alarm_min, (powerswitchlist,True))).start()
-
-      elif 'max' == part:
-        self.timer_max_data['lastaction'] = now
-        if 'on' == action and onduration > 0:
-          (Timer(onduration, self.toggle_off_alarm_max, (powerswitchlist,True))).start()
+      timerdata['lastaction'] = now
+      if 'lasttimer' in timerdata:
+        timerdata['lasttimer'].cancel()
+      if 'on' == action and onduration > 0:
+        timer = Timer(onduration, self.toggle_off_alarm_min if 'min' == part else self.toggle_off_alarm_max, (powerswitchlist,True))
+        timer.start()
+        timerdata['lasttimer'] = timer
 
   def set_alarm_min(self,start,stop,timer_on,timer_off,light_state,door_state,duration_on,settle,powerswitches):
     self.config['alarm_min'] = {'timer_start':start,


### PR DESCRIPTION
Fix for the scenario where a switch is turned off and on before the timer executes.

Here is an example scenario

1. Switch is toggled on with duration of 1 hour
2. Switch is toggled off after 30 minutes
3. Switch is toggled back on after another 10 minutes
4. Timer from 1 is still running and will toggle switch off in 20 minutes and another timer has been started