### PR TITLE
Fix bug with update config settings

### DIFF
--- a/terrariumEngine.py
+++ b/terrariumEngine.py
@@ -1611,10 +1611,10 @@ reset=$(tput sgr0)
         else:
           return False
 
-      # Update weather data
-      update_ok = self.set_weather_config({'location' : data['location']}) and self.set_system_config(data)
+      update_ok = self.set_system_config(data)
       if update_ok:
         # Update config settings
+        self.set_weather_config({'location' : data['location']})
         self.pi_power_wattage = float(self.config.get_pi_power_wattage())
         self.set_authentication(self.config.get_admin(),self.config.get_password())
 


### PR DESCRIPTION
As mentioned here #456, the "Data could not be saved" message appears when weather location left empty. You removed the weather requirement in the settings page but it was still mandatory in the terrariumEngine. Just a small code rearrangement :) 

Maybe one can add some live check if weather location is not valid and return a message and/or change the border color of the input field.