### PR TITLE
Fix add webcam with motiondeltathreshold not set

### DIFF
--- a/terrariumEngine.py
+++ b/terrariumEngine.py
@@ -459,15 +459,16 @@ class terrariumEngine(object):
 
         if 'motionboxes' in webcamdata:
           motion_boxes = webcamdata['motionboxes']
+          
+          if motion_boxes == "true":
+            if 'motion_delta_threshold' in webcamdata:
+              motion_delta_threshold = webcamdata['motiondeltathreshold']
 
-        if 'motion_delta_threshold' in webcamdata:
-          motion_delta_threshold = webcamdata['motiondeltathreshold']
+            if 'motion_min_area' in webcamdata:
+              motion_min_area = webcamdata['motionminarea']
 
-        if 'motion_min_area' in webcamdata:
-          motion_min_area = webcamdata['motionminarea']
-
-        if 'motion_compare_frame' in webcamdata:
-          motion_compare_frame = webcamdata['motioncompareframe']
+            if 'motion_compare_frame' in webcamdata:
+              motion_compare_frame = webcamdata['motioncompareframe']
 
         # don't let bad location data kill the system
         try:
@@ -515,15 +516,16 @@ class terrariumEngine(object):
 
       if 'motionboxes' in webcamdata:
         webcam.set_motion_boxes(webcamdata['motionboxes'])
+      
+      if webcamdata['motionboxes'] == "true":
+          if 'motiondeltathreshold' in webcamdata:
+            webcam.set_motion_delta_threshold(webcamdata['motiondeltathreshold'])
 
-      if 'motiondeltathreshold' in webcamdata:
-        webcam.set_motion_delta_threshold(webcamdata['motiondeltathreshold'])
+          if 'motionminarea' in webcamdata:
+            webcam.set_motion_min_area(webcamdata['motionminarea'])
 
-      if 'motionminarea' in webcamdata:
-        webcam.set_motion_min_area(webcamdata['motionminarea'])
-
-      if 'motioncompareframe' in webcamdata:
-        webcam.set_motion_compare_frame(webcamdata['motioncompareframe'])
+          if 'motioncompareframe' in webcamdata:
+            webcam.set_motion_compare_frame(webcamdata['motioncompareframe'])
 
       if 'awb' in webcamdata:
         webcam.set_awb(webcamdata['awb'])


### PR DESCRIPTION
Adding a webcam with archive set to any other option than "Motion" results in an error (debug) and no saving prompt in the UI:
`
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/bottle.py", line 868, in _handle
    return route.call(**args)
  File "/usr/local/lib/python3.7/dist-packages/bottle.py", line 1748, in wrapper
    rv = callback(*a, **ka)
  File "/home/pi/TerrariumPI/terrariumWebserver.py", line 44, in webserver_headers
    return fn(*args, **kwargs)
  File "/home/pi/TerrariumPI/terrariumWebserver.py", line 86, in wrapper
    return func(*a, **ka)
  File "/home/pi/TerrariumPI/terrariumWebserver.py", line 312, in __update_api_call
    result['ok'] = self.__terrariumEngine.set_config(path,postdata,request.files)
  File "/home/pi/TerrariumPI/terrariumEngine.py", line 1588, in set_config
    update_ok = self.set_webcams_config(data)
  File "/home/pi/TerrariumPI/terrariumEngine.py", line 1228, in set_webcams_config
    self.__load_webcams(data)
  File "/home/pi/TerrariumPI/terrariumEngine.py", line 522, in __load_webcams
    webcam.set_motion_delta_threshold(webcamdata['motiondeltathreshold'])
  File "/home/pi/TerrariumPI/terrariumWebcam.py", line 486, in set_motion_delta_threshold
    self.motion_delta_threshold = int(state)
ValueError: invalid literal for int() with base 10: ''
`

The webcam will appear somehow in the UI but is not saved in `settings.cfg` and gone after reboot.

One can consider adding default values in the `webcam_settings.tpl` or changing the `set_motion_delta_threshold` function. However, I've changed the logic slightly, so that only when "Motion" is selected at archive, related inputs will be used from the UI. Otherwise, default parameters will be used. 