### PR TITLE
Tasmota returns power status as 'POWERN' where N is the switch number

### DIFF
--- a/terrariumSwitch.py
+++ b/terrariumSwitch.py
@@ -798,7 +798,9 @@ class terrariumPowerSwitchSonoff(terrariumPowerSwitchSource):
         return self.state
 
       if 'tasmota' == self.__firmware:
-        return terrariumPowerSwitch.ON if terrariumUtils.is_true(state['POWER']) else terrariumPowerSwitch.OFF
+        for state_name, state_value in state.items():
+          if state_name.startswith('POWER'):
+            return terrariumPowerSwitch.ON if terrariumUtils.is_true(state_value) else terrariumPowerSwitch.OFF
       elif 'espeasy' == self.__firmware:
         return terrariumPowerSwitch.ON if terrariumUtils.is_true(state['POWER']) else terrariumPowerSwitch.OFF
       elif 'espurna' == self.__firmware:


### PR DESCRIPTION
When TerrariumPI goes to check the status of a switch on a Tasmota device, it responds with something like `{'POWER1': 'OFF'}` instead of the apparently more standard `{'POWER': 'OFF'}`.
This was throwing an error every time it checked my device statuses.

Presumably, the other firmwares don't need this little check, so it's just inside the Tasmota block.

This change seems to be working well in my instance.