### PR TITLE
Remove deprecated mac argument for pywemo

### DIFF
--- a/hardware/relay/wemo_relay.py
+++ b/hardware/relay/wemo_relay.py
@@ -20,7 +20,7 @@ class terrariumRelayWeMo(terrariumRelay):
     if port is None:
       raise terrariumRelayLoadingException(f'Relay {self} is not found')
 
-    device = pywemo.discovery.device_from_description(f'http://{self.address}:{port}/setup.xml', None)
+    device = pywemo.device_from_description(f'http://{self.address}:{port}/setup.xml')
     return device
 
   def _set_hardware_value(self, state):


### PR DESCRIPTION
The next version of pyWeMo will remove the `mac` argument to `device_from_description`. It has been an optional argument since [pywemo 0.8.0](https://github.com/pywemo/pywemo/releases/tag/0.8.0). TerrariumPI is currently using pywemo version 0.9.2.
https://github.com/theyosh/TerrariumPI/blob/79be755b0a0dd3260a6db00b1b5e0535a8dbd1c5/requirements.txt#L51

Further context: https://github.com/pywemo/pywemo/pull/367 (in the next release) - Deprecation: Remove the mac address argument