### PR TITLE
Change method of SBC model detection

### DIFF
--- a/terrariumEngine.py
+++ b/terrariumEngine.py
@@ -94,7 +94,7 @@ class terrariumEngine(object):
         self.update_available = False
         self.weather = None
         # Dirty hack... :(
-        self.device = re.search(r"Model\s+:\s+(?P<device>.*)", Path("/proc/cpuinfo").read_text()).group("device")
+        self.device = Path("/proc/device-tree/model").read_text().rstrip('\x00')
         init_db(self.version)
 
         # Send message that startup is ready..... else the startup will wait until done.... can take more then 1 minute
@@ -282,9 +282,7 @@ class terrariumEngine(object):
 
         # Load device information
         try:
-            settings["device"] = re.search(r"Model\s+:\s+(?P<device>.*)", Path("/proc/cpuinfo").read_text()).group(
-                "device"
-            )
+            settings["device"] = Path("/proc/device-tree/model").read_text().rstrip('\x00')
         except Exception as ex:
             logger.debug(f"Error getting Pi info: {ex}")
             settings["device"] = "Unknown"


### PR DESCRIPTION
This pulls the board model name from `/proc/device-tree/model` instead of `/proc/cpuinfo`. I made this change because I'm running a modified version of TerrariumPI on a Banana Pi M2 Zero that has an Armbian base, and its `/proc/cpuinfo` output didn't contain any useful information for pulling the model of the SBC. With this change, the resulting string is: `Banana Pi BPI-M2-Zero`

I also checked and confirmed that on a Raspberry Pi 3B+ running Raspberry Pi OS, this would produce the string: `Raspberry Pi 3 Model B Plus Rev 1.3`

NB: For my personal project, I changed line 285 to:
`settings["device"] = self.device`
to reuse the code, but this would probably need a little refactoring to preserve the error-checking logic of the try/except block.